### PR TITLE
Fix installing with --frozen-lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,7 +1107,7 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-pyright@^1.1.106:
+pyright@^1.1.108:
   version "1.1.108"
   resolved "https://registry.yarnpkg.com/pyright/-/pyright-1.1.108.tgz#28e06aa50aa3a85a8692ee0eb959b75f9905bd43"
   integrity sha512-LX6nLg1uu9DXSuvM4PeqSX2mVAzwoh8RfhTLK/W7zpEFYmdKVZXpJlgzwSfPVrRWjq/bEmj+hIYckkx0adBMjQ==


### PR DESCRIPTION
Installing the current master with `yarn install --frozen-lockfile` fails:

```
$ yarn install --frozen-lockfile
yarn install v1.22.10
[1/5] 🔍  Validating package.json...
warning coc-pyright@1.1.108: The engine "coc" appears to be invalid.
[2/5] 🔍  Resolving packages...
error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

This PR updates the lockfile by running `yarn install`.