### PR TITLE
Add "pyright.enable" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ These configurations are used by `coc-pyright`, you need to set them in your `co
 
 | Configuration | Description | Default |
 |  --- | --- | --- |
+| pyright.enable | Enable coc-pyright extension | true |
 | python.analysis.autoImportCompletions | Determines whether pyright offers auto-import completions | true |
 | python.analysis.autoSearchPaths | Automatically add common search paths like 'src' | true |
 | python.analysis.diagnosticMode | Analyzes and reports errors for open only or all files in workspace | openFilesOnly |

--- a/package.json
+++ b/package.json
@@ -87,6 +87,11 @@
       "type": "object",
       "title": "coc-pyright configuration",
       "properties": {
+        "pyright.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable coc-pyright extension"
+        },
         "python.analysis.extraPaths": {
           "type": "array",
           "default": [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,9 @@ async function provideHover(document: TextDocument, position: Position, token: C
 }
 
 export async function activate(context: ExtensionContext): Promise<void> {
+  const isEnable = workspace.getConfiguration('pyright').get<boolean>('enable', true);
+  if (!isEnable) return;
+
   const state = extensions.getExtensionState('coc-python');
   if (state.toString() === 'activated') {
     window.showMessage(`coc-python is installed and activated, coc-pyright will be disabled`, 'warning');


### PR DESCRIPTION
## Description

Added an option to enable/disable the coc-pyright extension.

This is used when you want to use other Python-related extensions besides coc-pyright at the project level.

For example, you may want to use `coc-jedi`, and your linter or formatter may use `coc-diagnostic`.

In such cases, it is useful to have an option to enable/disable the coc-pyright extension.

## Notes

If you have not intentionally added an enable/disable option setting, please close this PR. 🙇
