### PR TITLE
fix: support venv in Windows

### DIFF
--- a/src/configSettings.ts
+++ b/src/configSettings.ts
@@ -8,6 +8,7 @@ import { SystemVariables } from './systemVariables';
 import { IFormattingSettings, ILintingSettings, IPythonSettings, ISortImportSettings } from './types';
 
 export class PythonSettings implements IPythonSettings {
+  protected readonly isWindows = process.platform === 'win32';
   private workspaceRoot: string;
 
   private static pythonSettings: Map<string, PythonSettings> = new Map<string, PythonSettings>();
@@ -66,7 +67,7 @@ export class PythonSettings implements IPythonSettings {
       // poetry
       p = path.join(this.workspaceRoot, 'poetry.lock');
       if (fs.existsSync(p)) {
-        const list = child_process.spawnSync('poetry', ['env', 'list', '--full-path'], { encoding: 'utf8' }).stdout.trim();
+        const list = child_process.spawnSync('poetry', ['env', 'list', '--full-path', '--no-ansi'], { encoding: 'utf8' }).stdout.trim();
         let info = '';
         for (const item of list.split('\n')) {
           if (item.includes('(Activated)')) {
@@ -75,7 +76,12 @@ export class PythonSettings implements IPythonSettings {
           }
           info = item;
         }
-        if (info) return path.join(info, 'bin', 'python');
+        if (info) {
+          if (this.isWindows) {
+            return path.join(info, 'Scripts', 'python.exe');
+          }
+          return path.join(info, 'bin', 'python');
+        }
       }
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
Changes:

- disable ANSI output for poetry with `--no-ansi`, otherwise we get redundant characters in Python path:

  ```
  ^[[34mC:\Users\gerald\Git\ocr\.venv ^[[0m
  ```

- resolve Python path correctly in Windows, which should be `.venv/Scripts/python.exe`.