### PR TITLE
feat: Detect virtualenv in workspace root

### DIFF
--- a/src/configSettings.ts
+++ b/src/configSettings.ts
@@ -83,6 +83,17 @@ export class PythonSettings implements IPythonSettings {
           return path.join(info, 'bin', 'python');
         }
       }
+
+      // virtualenv in the workspace root
+      const files = fs.readdirSync(this.workspaceRoot);
+      for (const file of files) {
+        const p = path.join(this.workspaceRoot, file);
+
+        if (fs.existsSync(path.join(p, 'pyvenv.cfg'))) {
+          const pythonPath = path.join(p, 'bin', 'python');
+          return pythonPath;
+        }
+      }
     } catch (e) {
       console.error(e);
     }


### PR DESCRIPTION
This adds support for finding and setting the correct `pythonPath` if there's a virtualenv present in the workspace root directory.

This kind of works already if `cwd == workspaceRoot` (I assume Pyright itself does the correct thing?). But if you for example do `:e ../../other-project/foo.py` it will just use the interpreter available in `$PATH` even if there's both workspace root and a virtualenv in `../../other-project`.