### PR TITLE
chore: Change the download branch for json schema (master -> main)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     }
   ],
   "scripts": {
-    "schema": "curl -o schemas/pyrightconfig.schema.json https://raw.githubusercontent.com/microsoft/pyright/master/packages/vscode-pyright/schemas/pyrightconfig.schema.json && node diff.js",
+    "schema": "curl -o schemas/pyrightconfig.schema.json https://raw.githubusercontent.com/microsoft/pyright/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json && node diff.js",
     "clean": "rimraf lib",
     "lint": "eslint src --ext ts",
     "build": "node esbuild.js",


### PR DESCRIPTION
"pyright" repository seems to have been changed from the master branch to the main branch.

<img width="466" alt="pyright-repo" src="https://user-images.githubusercontent.com/188642/118211636-61e70400-b4a7-11eb-9ac0-d0b0ec1a31a6.png">

Currently it redirects, but I changed it because it might not be able to connect in the future.