### PR TITLE
fix: 2 spaces used for inline type: ignore comment

### DIFF
--- a/src/codeActionsProvider.ts
+++ b/src/codeActionsProvider.ts
@@ -53,7 +53,7 @@ export class PythonCodeActionProvider implements CodeActionProvider {
     if (this.lineRange(range)) {
       const line = doc.getline(range.start.line);
       if (line && line.length && !line.startsWith('#')) {
-        const edit = TextEdit.replace(range, `${line} # type: ignore${range.start.line + 1 === range.end.line ? '\n' : ''}`);
+        const edit = TextEdit.replace(range, `${line}  # type: ignore${range.start.line + 1 === range.end.line ? '\n' : ''}`);
         return {
           title: 'Ignore Pyright typing check for current line',
           edit: {


### PR DESCRIPTION
The issue https://github.com/fannheyward/coc-pyright/issues/404 regressed as of [this commit](https://github.com/fannheyward/coc-pyright/commit/c599f6f4d0fa53e13adc44df80bc48f904186dfe).
This corrects coc-pyright to use 2 spaces before inline "type: ignore" comments as per pep8.