### PR TITLE
fix: pass "--no-pretty" to mypy by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -877,7 +877,8 @@
           "default": [
             "--ignore-missing-imports",
             "--follow-imports=silent",
-            "--show-column-numbers"
+            "--show-column-numbers",
+            "--no-pretty"
           ],
           "items": {
             "type": "string"


### PR DESCRIPTION
If `pretty = true` is configured via configuration files like pyproject.toml, setup.cfg or mypy.ini it sometimes truncates the error message displayed by coc-pyright.

This is because it changes the output format:

```console
$ cat > foo.py <<EOF
def foo(a: int):
    pass

foo("123")
EOF
$ mypy --pretty foo.py
foo.py:8:5: error: Argument 1 to "foo" has incompatible type "str"; expected "int"
    foo("123")
        ^
Found 1 error in 1 file (checked 1 source file)
$ mypy --no-pretty foo.py
foo.py:8:5: error: Argument 1 to "foo" has incompatible type "str"; expected "int"
Found 1 error in 1 file (checked 1 source file)
```