### PR TITLE
Clarify location of other config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ These configurations are used by `coc-pyright`, you need to set them in your `co
 | pyright.completion.snippetSupport           | Enable completion snippets support                                  | true          |
 | pyright.organizeimports.provider            | Organize imports provider, `pyright` or `isort`                     | pyright       |
 
+Additional configuration options can be found in [package.json](./package.json).
+
 ## pyrightconfig.json
 
 Pyright supports [pyrightconfig.json](https://github.com/microsoft/pyright/blob/master/docs/configuration.md) that provide granular control over settings.


### PR DESCRIPTION
I just added a line in `README.md` that calls out the additional configuration settings found in `package.json`. This would have been extremely helpful for me (someone who is unfamiliar with the location of things in a project like this). 