### PR TITLE
Give private members lower suggestion priority

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,8 @@ async function provideCompletionItem(document: TextDocument, position: Position,
 
   const items = Array.isArray(result) ? result : result.items;
   items.map((x) => delete x.sortText);
-  items.sort((a, b) => (a.kind && b.kind ? a.kind - b.kind : 0));
+  const privateLevel = (x) => (x.insertText || x.label).match(/^_*/)[0].length;
+  items.sort((a, b) => (privateLevel(a) - privateLevel(b) || (a.kind && b.kind ? a.kind - b.kind : 0)));
 
   const snippetSupport = workspace.getConfiguration('pyright').get<boolean>('completion.snippetSupport');
   if (snippetSupport) {


### PR DESCRIPTION
Currently private member suggestions are interspersed with public ones and are rarely needed. Most implementations (e.g. pyright's sortText, pycharm) give lower priority to them.

### Before
![image](https://user-images.githubusercontent.com/45873379/151674115-a0e146c2-bd4e-41a1-bf05-b43010bc1c24.png)

### After
![image](https://user-images.githubusercontent.com/45873379/151674110-c202d2a2-a20f-48ab-8594-b8a0296062da.png)