### PR TITLE
refactor(inlayHints): code changes for vim9 support

### DIFF
--- a/src/features/inlayHints.ts
+++ b/src/features/inlayHints.ts
@@ -62,7 +62,7 @@ export class TypeInlayHintsProvider implements InlayHintsProvider {
 
           switch (item.inlayHintType) {
             case 'variable':
-              inlayHintPosition = startPosition;
+              inlayHintPosition = Position.create(startPosition.line, endPosition.character + 1);
               break;
             case 'functionReturn':
               inlayHintPosition = endPosition;
@@ -75,6 +75,8 @@ export class TypeInlayHintsProvider implements InlayHintsProvider {
             const inlayHint: InlayHint = {
               label: inlayHintLabelPart,
               position: inlayHintPosition,
+              paddingLeft: item.inlayHintType === 'functionReturn' ?? true,
+              paddingRight: item.inlayHintType === 'variable' ?? true,
             };
 
             inlayHints.push(inlayHint);


### PR DESCRIPTION
## Description

The inlay hints in `coc-pyright-tools` were implemented only with the assumption of adding inlay hints at the end of lines, since coc.nvim supported only `Neovim`.

Inlay hints are now supported in `Vim9`, so I adjusted the positions, etc.

## DEMO (mp4)

### Before

https://user-images.githubusercontent.com/188642/186540451-d25117b8-ba0a-46c0-acfb-812c118460ff.mp4

### After

https://user-images.githubusercontent.com/188642/186540467-a7c969b4-778d-4396-8403-c5db61fa7f25.mp4
