### PR TITLE
feat: add support for endLine/endColumn to linters

### DIFF
--- a/src/features/linters/lintingEngine.ts
+++ b/src/features/linters/lintingEngine.ts
@@ -165,7 +165,9 @@ export class LintingEngine {
 
   private createDiagnostics(message: ILintMessage, document: TextDocument): Diagnostic {
     let start = Position.create(message.line > 0 ? message.line - 1 : 0, message.column);
-    let end = Position.create(message.line > 0 ? message.line - 1 : 0, message.column + 1);
+    const endLine = message.endLine ?? message.line;
+    const endColumn = message.endColumn ?? message.column + 1;
+    let end = Position.create(endLine > 0 ? endLine - 1 : 0, endColumn);
 
     const ms = /['"](.*?)['"]/g.exec(message.message);
     if (ms && ms.length > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,8 @@ export enum LintMessageSeverity {
 export interface ILintMessage {
   line: number;
   column: number;
+  endLine?: number;
+  endColumn?: number;
   code: string | undefined;
   message: string;
   type: string;


### PR DESCRIPTION
Some linters have support for error ranges (e.g. Ruff) which gives nicer diagnostics since they mark the entire error region instead of just the first character.

Before:
![Screenshot 2022-11-30 at 12 23 07](https://user-images.githubusercontent.com/177685/204783764-6322a5e8-8c33-4b4d-b699-1973136bf0cb.png)

After:
![Screenshot 2022-11-30 at 12 22 43](https://user-images.githubusercontent.com/177685/204783768-b68fff54-6571-4d8b-a72b-ae9e56a28c88.png)

Issue #853