### PR TITLE
Remove extra space after inlay hint for variables

### DIFF
--- a/src/features/inlayHints.ts
+++ b/src/features/inlayHints.ts
@@ -76,7 +76,6 @@ export class TypeInlayHintsProvider implements InlayHintsProvider {
               label: inlayHintLabelPart,
               position: inlayHintPosition,
               paddingLeft: item.inlayHintType === 'functionReturn' ?? true,
-              paddingRight: item.inlayHintType === 'variable' ?? true,
             };
 
             inlayHints.push(inlayHint);


### PR DESCRIPTION
Previously the inlay hint for variables would include a space at the end. This meant that if you had a space between the variable and =, two spaces would be displayed between the hint and =.

This looks pretty ugly imo, and means that with normal formatting there would be a different amount of spaces for the inlay hints and the explicit hints in the code.

Before:
![image](https://user-images.githubusercontent.com/601966/212489712-2671f746-474d-4e64-9684-51ca35e4aad6.png)

After:
![image](https://user-images.githubusercontent.com/601966/212489686-2922ae6a-2acb-4682-9e48-2fd00dfa82dd.png)