### PR TITLE
feat: add Pipfile to rootPatterns in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
         "patterns": [
           "app.py",
           "setup.py",
+          "Pipfile",
           "setup.cfg",
           "manage.py",
           "pyproject.toml",


### PR DESCRIPTION
# Motivation

I have multiple projects in monolithic git repositories. These projects have somewhat of the following structure:
```
/project
- Has .git folder, .gitignore, etc
    /bot - python discord bot
    - Pipfile, bot.py, etc
    /frontend - react, astro, whathave you
    - misc js files (unimportant)
    /[others]
```
Since these monorepos potentially have multiple python projects in them, each with their own Pipfile, I would like
pyright to be able to automatically find the venv for the sub folder containing the pipfile.

I have tried to do this on my own by adding a `pyrightconfig.json` with
```json
{
    "executionEnvironments": [{
        "root": "bot"
        }
    ]
}
```
However this did not solve the problem, and seemed to have no effect.
I also tried overriding parts of coc-config / coc-local-config, However neither of these worked, nor did any of the methods from [this](https://github.com/neoclide/coc.nvim/wiki/Using-workspaceFolders#resolve-workspace-folder) guide.

# Reasoning for PR

`activationEvents` already contains Pipfile, along with basically all the other patterns listed in `rootPatterns`, and is a reasonable
indication of a workspace folder.

## Note

I am no expert on how pyright works under the hood, nor am I any expert at navigating all of the configuration of LSPs and such, but
for the life of me I could not find a solution for this that could be easily shared with my team. If anyone has suggestions that would
be portable (i.e upload-able to git so it just "works" for other devs), please let me know. Thanks!
