### PR TITLE
Add more root patterns for multi-modules workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,9 @@
           "manage.py",
           "pyproject.toml",
           "requirements.txt",
-          "pyrightconfig.json"
+          "pyrightconfig.json",
+          "tox.ini",
+          "pytest.ini"
         ]
       }
     ],


### PR DESCRIPTION
Example layout:

    xxx
    ├── project-a
    │   └── setup.py
    ├── project-b
    │   └── setup.py
    ├── pytest.ini
    ├── tox.ini
    └── venv
        └── pyvenv.cfg

Without the extra root patterns, the workspace root would be detected as `xxx/project-a` or `xxx/project-b`. Neither of them contains the `venv` directory.