### PR TITLE
fix: checking unittest framework exists can be slow

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -11,7 +11,11 @@ const framework = workspace.getConfiguration('pyright').get<TestingFramework>('t
 
 function validPythonModule(pythonPath: string, moduleName: string) {
   try {
-    const pythonProcess = child_process.spawnSync(pythonPath, ['-m', moduleName, '--help'], { encoding: 'utf8' });
+    const pythonProcess = child_process.spawnSync(
+      pythonPath,
+      ['-c', `from importlib.machinery import PathFinder; assert PathFinder.find_spec("${moduleName}") is not None`],
+      { encoding: 'utf8' },
+    );
     if (pythonProcess.error) return false;
     return pythonProcess.status === 0;
   } catch (ex) {


### PR DESCRIPTION
Sometimes importing a test framework such as pytest can trigger importing other code that has a longer runtime on import than allowed by the spawned process. This fixes the issue by checking that the import path can be found, which does not trigger importing the code.